### PR TITLE
Add ENV PIP_BREAK_SYSTEM_PACKAGES=1 to the Dockerfile.

### DIFF
--- a/x.o.n-streaming-client/Dockerfile
+++ b/x.o.n-streaming-client/Dockerfile
@@ -11,6 +11,7 @@ ARG DISTRIB_RELEASE
 
 LABEL maintainer="https://github.com/ehfd,https://github.com/danisla"
 
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG DEBIAN_FRONTEND=noninteractive
 # Configure rootless user environment for constrained conditions without escalated root privileges inside containers
 ARG TZ=UTC


### PR DESCRIPTION
This resolves a `docker build` failure caused by pip being unable to uninstall an apt-installed package (`blinker`). Setting this environment variable allows pip to manage system-wide packages, which is necessary in this environment where apt and pip installations are mixed.