### PR TITLE
Fix Python dependency conflicts in Docker build

### DIFF
--- a/x.o.n-streaming-client/Dockerfile
+++ b/x.o.n-streaming-client/Dockerfile
@@ -11,7 +11,6 @@ ARG DISTRIB_RELEASE
 
 LABEL maintainer="https://github.com/ehfd,https://github.com/danisla"
 
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG DEBIAN_FRONTEND=noninteractive
 # Configure rootless user environment for constrained conditions without escalated root privileges inside containers
 ARG TZ=UTC
@@ -521,7 +520,6 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
     fi
 
 # Install latest Selkies (https://github.com/selkies-project/selkies) build, Python application, and web application, should be consistent with Selkies documentation
-ARG PIP_BREAK_SYSTEM_PACKAGES=1
 RUN apt-get update && apt-get install --no-install-recommends -y \
         # GStreamer dependencies
         python3-pip \
@@ -568,10 +566,20 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         libxtst6 \
         libxext6 && \
     if [ "$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '\"')" \> "20.04" ]; then apt-get install --no-install-recommends -y xcvt libopenh264-dev svt-av1 aom-tools; else apt-get install --no-install-recommends -y mesa-utils-extra; fi && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/* /tmp/* /var/tmp/*
+
+# Create and activate a Python virtual environment
+ENV VENV_PATH=/opt/venv
+RUN python3 -m venv ${VENV_PATH} && \
+    chown -R ubuntu:ubuntu ${VENV_PATH}
+ENV PATH="${VENV_PATH}/bin:${PATH}"
+
+# Install Python dependencies into the virtual environment
+RUN \
     # Automatically fetch the latest Selkies version and install the components
     SELKIES_VERSION="$(curl -fsSL "https://api.github.com/repos/selkies-project/selkies/releases/latest" | jq -r '.tag_name' | sed 's/[^0-9\.\-]*//g')" && \
     cd /opt && curl -fsSL "https://github.com/selkies-project/selkies/releases/download/v${SELKIES_VERSION}/gstreamer-selkies_gpl_v${SELKIES_VERSION}_ubuntu$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '\"')_$(dpkg --print-architecture).tar.gz" | tar -xzf - && \
-    cd /tmp && curl -O -fsSL "https://github.com/selkies-project/selkies/releases/download/v${SELKIES_VERSION}/selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && pip3 install --no-cache-dir --force-reinstall "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" "websockets<14.0" && rm -f "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && \
+    cd /tmp && curl -O -fsSL "https://github.com/selkies-project/selkies/releases/download/v${SELKIES_VERSION}/selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && pip install --no-cache-dir --force-reinstall "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" "websockets<14.0" && rm -f "selkies_gstreamer-${SELKIES_VERSION}-py3-none-any.whl" && \
     cd /opt && curl -fsSL "https://github.com/selkies-project/selkies/releases/download/v${SELKIES_VERSION}/selkies-gstreamer-web_v${SELKIES_VERSION}.tar.gz" | tar -xzf - && \
     cd /tmp && curl -o selkies-js-interposer.deb -fsSL "https://github.com/selkies-project/selkies/releases/download/v${SELKIES_VERSION}/selkies-js-interposer_v${SELKIES_VERSION}_ubuntu$(grep '^VERSION_ID=' /etc/os-release | cut -d= -f2 | tr -d '\"')_$(dpkg --print-architecture).deb" && apt-get update && apt-get install --no-install-recommends -y ./selkies-js-interposer.deb && rm -f selkies-js-interposer.deb && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/debconf/* /var/log/* /tmp/* /var/tmp/*
@@ -602,7 +610,7 @@ RUN chmod -f 755 /etc/supervisord.conf
 # Copy and set up the game launch agent
 COPY --chown=1000:1000 agent.py /home/ubuntu/agent.py
 RUN chmod -f 755 /home/ubuntu/agent.py && \
-    pip3 install --no-cache-dir --force-reinstall "Flask>=2.0" "Flask-Cors>=3.0"
+    pip install --no-cache-dir --force-reinstall "Flask>=2.0" "Flask-Cors>=3.0"
 
 # Configure coTURN script
 RUN echo "#!/bin/bash\n\

--- a/x.o.n-streaming-client/entrypoint.sh
+++ b/x.o.n-streaming-client/entrypoint.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -e
+set -ex
 
 trap "echo TRAPed signal" HUP INT QUIT TERM
 

--- a/x.o.n-streaming-client/kasmvnc-entrypoint.sh
+++ b/x.o.n-streaming-client/kasmvnc-entrypoint.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -e
+set -ex
 
 # Wait for XDG_RUNTIME_DIR
 until [ -d "${XDG_RUNTIME_DIR}" ]; do sleep 0.5; done

--- a/x.o.n-streaming-client/selkies-gstreamer-entrypoint.sh
+++ b/x.o.n-streaming-client/selkies-gstreamer-entrypoint.sh
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set -e
+set -ex
 
 # Wait for XDG_RUNTIME_DIR
 until [ -d "${XDG_RUNTIME_DIR}" ]; do sleep 0.5; done


### PR DESCRIPTION
Refactored the Dockerfile to use a Python virtual environment (`venv`).

Previously, `pip` was installing packages into the system's Python site-packages, which conflicted with packages installed by `apt`, causing the build to fail with a `Cannot uninstall blinker` error.

This change introduces a virtual environment at /opt/venv and ensures all `pip` installations happen within this isolated environment, which is the standard best practice for managing Python dependencies in Docker. The `PIP_BREAK_SYSTEM_PACKAGES` workaround has been removed.

Additionally, added the `-x` flag (`set -ex`) to the main entrypoint scripts to enable verbose command logging, which will make future debugging easier as requested.