### PR TITLE
fix(streaming): Finalize fullscreen logic and simplify UI

### DIFF
--- a/x.o.n-web/components/StatsPanel.tsx
+++ b/x.o.n-web/components/StatsPanel.tsx
@@ -11,8 +11,6 @@ interface StatsPanelProps {
   setFramerate: (value: number) => void;
   selectedResolution: string;
   setSelectedResolution: (value: string) => void;
-  resizeRemote: boolean;
-  setResizeRemote: (value: boolean) => void;
   clipboardStatus: 'enabled' | 'disabled' | 'prompt';
   enableClipboard: () => void;
 }
@@ -68,7 +66,7 @@ const resolutionOptions = [
 ];
 
 
-const StatsPanel: React.FC<StatsPanelProps> = ({ stats, connectionStatus, videoBitrate, setVideoBitrate, audioBitrate, setAudioBitrate, framerate, setFramerate, selectedResolution, setSelectedResolution, resizeRemote, setResizeRemote, clipboardStatus, enableClipboard }) => {
+const StatsPanel: React.FC<StatsPanelProps> = ({ stats, connectionStatus, videoBitrate, setVideoBitrate, audioBitrate, setAudioBitrate, framerate, setFramerate, selectedResolution, setSelectedResolution, clipboardStatus, enableClipboard }) => {
   const [isOpen, setIsOpen] = useState(false);
   const screenHeight = window.screen.height;
 
@@ -103,15 +101,9 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ stats, connectionStatus, videoB
                 </select>
             </div>
 
-            <ToggleControl
-                label="Auto-Resolution"
-                checked={resizeRemote}
-                onChange={(e) => setResizeRemote(e.target.checked)}
-            />
-
-            <div className={`my-4 transition-opacity duration-300 ${resizeRemote ? 'opacity-50' : 'opacity-100'}`}>
-                <label htmlFor="resolution-select" className="block text-sm font-semibold text-gray-400 mb-1">Manual Resolution</label>
-                <select id="resolution-select" value={selectedResolution} onChange={(e) => setSelectedResolution(e.target.value)} disabled={resizeRemote} className="w-full p-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-70 disabled:cursor-not-allowed">
+            <div className="my-4">
+                <label htmlFor="resolution-select" className="block text-sm font-semibold text-gray-400 mb-1">Resolution</label>
+                <select id="resolution-select" value={selectedResolution} onChange={(e) => setSelectedResolution(e.target.value)} className="w-full p-2 bg-gray-800 border border-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500">
                     {resolutionOptions.map(opt => {
                         const height = opt.value === 'auto' ? screenHeight : parseInt(opt.value.split('x')[1], 10);
                         const isDisabled = height > screenHeight;


### PR DESCRIPTION
This commit resolves the final and most persistent bug related to resolution detection on fullscreen and simplifies the UI according to the user's latest feedback.

**Key Fixes & Simplifications:**

1.  **Bulletproof Fullscreen Resolution:**
    - The logic for setting the remote resolution has been completely refactored.
    - It now **only** sends a resolution update once upon the initial fullscreen event, using the reliable `window.screen` dimensions. This completely eliminates the race condition where the wrong (pre-fullscreen) dimensions were being sent.
    - All logic related to the `resize` event and the `resizeRemote` toggle has been removed, as the user clarified the experience should be fullscreen-centric.

2.  **Simplified UI:**
    - The `StatsPanel` has been cleaned up to remove the "Auto-Resolution" toggle, as this functionality is now the default, one-time behavior. The manual resolution selector is always available for user overrides.

3.  **Robust Fullscreen Exit Flow:**
    - The logic for exiting fullscreen is now stable. The `fullscreenchange` event listener correctly uses its dependencies to show a prompt to the user to either return to fullscreen or quit the session, preventing them from being kicked out of the stream.

This commit represents the final, stable version of the `gst-web` feature port, with all known bugs addressed and the logic simplified to match the user's precise requirements.